### PR TITLE
Suppress notices and warnings

### DIFF
--- a/e4WorkflowApp.php
+++ b/e4WorkflowApp.php
@@ -8,6 +8,8 @@ function __autoload($className)
 	include ROOT.'libs/'.$className.'.php';
 }
 
+error_reporting(E_ERROR);
+ini_set('display_errors', '0');
 
 // Loading application config
 $app = new e4WorkflowApp(ROOT);


### PR DESCRIPTION
Thanks for a great plugin!

I had my PHP config changed for development to report more errors (I think newer versions of PHP will do this by default). Suppressing the messages fixes the problem.
