### PR TITLE
Run result through `number_format` to get thousand separators

### DIFF
--- a/libs/e4WorkflowDoConvert.php
+++ b/libs/e4WorkflowDoConvert.php
@@ -54,10 +54,10 @@ class e4WorkflowDoConvert extends e4WorkflowCommands
 						'uid' => 'none',
 						'arg' => $tmpResponse->getToAmount(),
 						'title' => implode(' ', array(
-							$tmpResponse->getFromAmount(),
+							number_format($tmpResponse->getFromAmount(), 2),
 							$tmpResponse->getFromCurrency(),
 							'=',
-							$tmpResponse->getToAmount(),
+							number_format($tmpResponse->getToAmount(), 2),
 							$tmpResponse->getToCurrency())),
 						'subtitle' => 'Processed by '.$tmpResponse->getService(),
 						'icon' => 'icon.png',


### PR DESCRIPTION
This makes it easier to read large numbers, e.g. `1,432,678,321`.

Without additional arguments `number_format` will use commas for thousand separates, if you think this may confuse people who run macOS with a different locale setting then I suggest using a thin space (U+2009) as a workaround for (presumably) being unable to get the system’s configured thousand separator.

I was considering also running the suggestion through `number_format`, e.g. writing `currency 50000 D` will show `50000 DKK` which I would like to see as `50,000 DKK`, but that requires a bit of refactoring, as the suggestion is returned from a helper function and used both as title and what is inserted for auto-completion.
